### PR TITLE
Fixed a warning in flutter 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.1
+### FIX
+- Fixed warnings for Flutter3.0.0 
+  - Wrapped code containing warnings in `_ambiguate()`
+
 ## 1.1.0
 ### FEAT
 - Added `InAppNotification.dismiss()` method that hides notification programmatically.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -66,7 +66,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.1.1"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/size_listenable_container.dart
+++ b/lib/src/size_listenable_container.dart
@@ -4,6 +4,8 @@ import 'package:flutter/widgets.dart';
 
 // reference: https://qiita.com/najeira/items/0ff716971184042b1434
 
+T? _ambiguate<T>(T? value) => value;
+
 typedef SizeChangedCallback = void Function(Size size);
 
 class SizeListenableContainer extends SingleChildRenderObjectWidget {
@@ -42,7 +44,7 @@ class _SizeListenableRenderObject extends RenderProxyBox {
   }
 
   void _callback(Size size) {
-    SchedulerBinding.instance!.addPostFrameCallback((_) {
+    _ambiguate(SchedulerBinding.instance)!.addPostFrameCallback((_) {
       onSizeChanged(size);
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: in_app_notification
 description: A Flutter package to show custom in-app notification with any Widgets.
-version: 1.1.0
+version: 1.1.1
 repository: https://github.com/cb-cloud/flutter_in_app_notification
 
 environment:

--- a/test/in_app_notification_test.dart
+++ b/test/in_app_notification_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:in_app_notification/in_app_notification.dart';
 import 'package:in_app_notification/src/size_listenable_container.dart';
 
+T? _ambiguate<T>(T? value) => value;
+
 void main() {
   Widget base(Key key) => MaterialApp(
         home: InAppNotification(
@@ -17,7 +19,7 @@ void main() {
 
   setUp(() {
     TestWidgetsFlutterBinding.ensureInitialized();
-    WidgetsBinding.instance!.resetEpoch();
+    _ambiguate(WidgetsBinding.instance)!.resetEpoch();
   });
 
   testWidgets('SizeListenableContainer test.', (tester) async {


### PR DESCRIPTION
Fixed warning for flutter 3.0.0

_ambiguate is a fix for warning below version 3.0.0.
If you do not need, please remove it.

https://docs.flutter.dev/development/tools/sdk/release-notes/release-notes-3.0.0#your-code