### PR TITLE
Guard size change detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.2
+### FIX
+- Prevent some `Completer` error.
+  - When the size of a notification was changed unexpectedly, a `Future already completed.` error could occur.
+
 ## 1.1.1
 ### FIX
 - Fixed warnings for Flutter3.0.0 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -66,7 +66,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.1"
+    version: "1.1.2"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/in_app_notification.dart
+++ b/lib/src/in_app_notification.dart
@@ -135,6 +135,7 @@ class _NotificationController extends InheritedWidget {
           width: state.screenSize.width,
           child: SizeListenableContainer(
             onSizeChanged: (size) {
+              if (state.notificationSizeCompleter.isCompleted) return;
               final topPadding = MediaQuery.of(context).viewPadding.top;
               state.notificationSizeCompleter
                   .complete(size + Offset(0, topPadding));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: in_app_notification
 description: A Flutter package to show custom in-app notification with any Widgets.
-version: 1.1.1
+version: 1.1.2
 repository: https://github.com/cb-cloud/flutter_in_app_notification
 
 environment:


### PR DESCRIPTION
This will prevent some error like `Bad state: Future already completed. `.