### PR TITLE
modify: fix OverlayEntry can't be removed correctly while window size changed

### DIFF
--- a/lib/src/vsync_provider.dart
+++ b/lib/src/vsync_provider.dart
@@ -30,9 +30,12 @@ class __VsyncProviderState extends State<_VsyncProvider>
     duration: notificationHorizontalAnimationDuration,
   );
 
+  _NotificationController? _notificationController;
+
   @override
   Widget build(BuildContext context) {
-    return _NotificationController(
+    _notificationController?.state.overlay?.remove();
+    _notificationController = _NotificationController(
       state: _NotificationState(
         showController: _showController,
         verticalAnimationController: _verticalAnimationController,
@@ -40,6 +43,7 @@ class __VsyncProviderState extends State<_VsyncProvider>
       ),
       child: widget.child,
     );
+    return _notificationController!;
   }
 
   @override
@@ -47,6 +51,7 @@ class __VsyncProviderState extends State<_VsyncProvider>
     _showController.dispose();
     _verticalAnimationController.dispose();
     _horizontalAnimationController.dispose();
+    _notificationController?.state.overlay?.remove();
     super.dispose();
   }
 }

--- a/lib/src/vsync_provider.dart
+++ b/lib/src/vsync_provider.dart
@@ -35,7 +35,7 @@ class __VsyncProviderState extends State<_VsyncProvider>
   @override
   Widget build(BuildContext context) {
     _notificationController?.state.overlay?.remove();
-    _notificationController = _NotificationController(
+    _notificationController ??= _NotificationController(
       state: _NotificationState(
         showController: _showController,
         verticalAnimationController: _verticalAnimationController,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.1.2
 repository: https://github.com/cb-cloud/flutter_in_app_notification
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
I found a problem: if I change window size on destop, the previous OverlayEntry can't be removed from `Navigator.of(context)`.overlay correctly. 

I checked and found the problem is that while window size changed, the `InAppNotification` will be rebuilt, and then the `_VsyncProvider` is rebuilt. However, the `build()` method of `__VsyncProviderState` returns a `_NotificationController()`, where the `_NotificationState` is created. 

Which means, while window size changed, the previous `_NotificationState` is missed after `InAppNotification` rebuilt , with the OverlayEntry missed. 

So I choose to save `_NotificationController` in `__VsyncProviderState`. Before `_VsyncProvider `is rebuilt, the previous OverlayEntry can removed correctly.

Also, I confirm that this package can work well with flutter 3.10.6 and dart 3.0.6, so I changed dart SDK version to '<4.0.0'.